### PR TITLE
Fixes #2 Feedback / after-the-fact-review of XPathTransformer :)

### DIFF
--- a/src/main/java/org/datacleaner/extension/xml/XPathTransformer.java
+++ b/src/main/java/org/datacleaner/extension/xml/XPathTransformer.java
@@ -57,7 +57,7 @@ public class XPathTransformer implements Transformer {
     private TransformerFactory transformerFactory;
 
     @Initialize
-    public void init() {
+    public void init() throws IllegalArgumentException {
         final XPath xPath = XPathFactory.newInstance().newXPath();
 
         compiledExpressions = new XPathExpression[xPathExpressions.length];
@@ -66,8 +66,8 @@ public class XPathTransformer implements Transformer {
             try {
                 compiledExpressions[i] = xPath.compile(xPathExpressions[i]);
             } catch (XPathExpressionException e) {
-                componentContext.publishMessage(new ExecutionLogMessage("Error occurred compiling XPath expression: \""
-                        + xPathExpressions[i] + "\"."));
+                throw new IllegalArgumentException("Error occurred compiling XPath expression: \""
+                        + xPathExpressions[i] + "\".");
             }
         }
 
@@ -126,8 +126,8 @@ public class XPathTransformer implements Transformer {
                     transformedNodes.add(writeDocumentToString(results.item(i)));
                 }
             } catch (XPathExpressionException e) {
-            componentContext.publishMessage(new ExecutionLogMessage("Error occurred compiling XPath expression: \""
-                    + xPathExpression + "\"."));
+                componentContext.publishMessage(new ExecutionLogMessage("Error occurred compiling XPath expression: \""
+                        + xPathExpression + "\"."));
             } catch (TransformerException e) {
                 componentContext.publishMessage(new ExecutionLogMessage("Error occurred applying XPath expression: \""
                         + xPathExpression + "\" to xml."));

--- a/src/test/java/org/datacleaner/extension/xml/XPathTransformerTest.java
+++ b/src/test/java/org/datacleaner/extension/xml/XPathTransformerTest.java
@@ -11,9 +11,14 @@ import org.datacleaner.data.MockInputColumn;
 import org.datacleaner.data.MockInputRow;
 import org.easymock.EasyMock;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class XPathTransformerTest {
+    @Rule
+    public final ExpectedException expectedException = ExpectedException.none();
+    
     private static final String EXAMPLE_XML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
             + "<books>"
                 + "<book>Robinson Crusoe</book>"
@@ -77,13 +82,11 @@ public class XPathTransformerTest {
 
     @Test
     public void testIllegalXPathQuery() {
-        MockInputRow inputRow = new MockInputRow(new MockInputColumn<?>[] {
-                (MockInputColumn<?>) xPathTransformer.column }, new String[] { EXAMPLE_XML });
-
         xPathTransformer.xPathExpressions = new String[] { "<abracadabra>" };
+        
+        expectedException.expect(IllegalArgumentException.class);
+        expectedException.expectMessage("Error occurred compiling XPath expression: \"<abracadabra>\"");
         xPathTransformer.init();
-
-        assertThat(xPathTransformer.transform(inputRow)[0], is(Arrays.asList(new String[] {})));
     }
 
     @Test


### PR DESCRIPTION
- Refactored the initialize method so it throws an Exception in case an XPath expression can't be compiled.
- I don't see what I could validate in a `@Validate` annotated method, because the only thing that could cause problems which would cause a job to run with invalid configuration are the configured XPath expressions, which already cause the initialize method to throw an Exception now. Maybe I'm missing something here however.
- The XmlUtils class is not available in DataCleaner 4.5.3 which this extension depends on, therefore I didn't use it.
